### PR TITLE
Add TotalCost property to OrderDTO class

### DIFF
--- a/Models/DTOs/OrderDTO.cs
+++ b/Models/DTOs/OrderDTO.cs
@@ -12,4 +12,12 @@ public class OrderDTO
     public PaintColorDTO? PaintColor { get; set; }
     public int InteriorId { get; set; }
     public InteriorDTO? Interior { get; set; }
+
+    public decimal TotalCost
+    {
+        get
+        {
+            return Wheels.Price + Technology.Price + PaintColor.Price + Interior.Price;
+        }
+    }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -134,18 +134,21 @@ app.MapGet("/orders", () =>
                 Price = wheel.Price,
                 Style = wheel.Style
             },
+            TechnologyId = o.TechnologyId,
             Technology = technology == null ? null : new TechnologyDTO
             {
                 Id = technology.Id,
                 Price = technology.Price,
                 Package = technology.Package
             },
+            InteriorId = o.InteriorId,
             Interior = interior == null ? null : new InteriorDTO
             {
                 Id = interior.Id,
                 Price = interior.Price,
                 Material = interior.Material
             },
+            PaintId = o.PaintId,
             PaintColor = paintColor == null ? null : new PaintColorDTO
             {
                 Id = paintColor.Id,


### PR DESCRIPTION
### Description

This PR enhances the Car Builder API to include related data properties in the `Order` class and the `OrderDTO`. It adds a calculated property `TotalCost` to `OrderDTO` that sums the prices of all options in an order.

### Changes

- Added related data properties (`Wheels`, `Technology`, `PaintColor`, `Interior`) to the `Order` class.
- Updated the `OrderDTO` class to include properties for the related data and a calculated `TotalCost` property.
- Updated the GET /orders endpoint to include the related data in the response and calculate the total cost.

### Testing Instructions

1. Start the API server.
2. Use Postman or a similar tool to send a GET request to `/orders` and verify that the response includes the related data and the correct total cost for each order.
3. Place a new order using the frontend application and verify that the total cost is calculated correctly.